### PR TITLE
Added preferences activity to demo app DEV-500

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,13 +35,14 @@ proguard/
 # Android Studio captures folder
 captures/
 
-# Intellij
+# IntelliJ
 *.iml
 .idea/workspace.xml
 .idea/tasks.xml
 .idea/gradle.xml
 .idea/dictionaries
 .idea/libraries
+.idea/caches
 
 # Keystore files
 # Uncomment the following line if you do not want to check your keystore files in.
@@ -57,6 +58,31 @@ google-services.json
 freeline.py
 freeline/
 freeline_project_description.json
+
+# fastlane
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots
+fastlane/test_output
+fastlane/readme.md
+
+## Gradle.gitignore
+## https://github.com/github/gitignore
+
+.gradle
+/build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Cache of project
+.gradletasknamecache
+
+# # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
+# gradle/wrapper/gradle-wrapper.properties
 
 ## Java.gitignore
 ## https://github.com/github/gitignore
@@ -84,43 +110,38 @@ freeline_project_description.json
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
-# # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
-# gradle/wrapper/gradle-wrapper.properties
-
 ## JetBrains.gitignore
 ## https://github.com/github/gitignore
 
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
-# User-specific stuff:
+# User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml
 .idea/dictionaries
 
-# Sensitive or high-churn files:
+# Sensitive or high-churn files
 .idea/**/dataSources/
 .idea/**/dataSources.ids
-.idea/**/dataSources.xml
 .idea/**/dataSources.local.xml
 .idea/**/sqlDataSources.xml
 .idea/**/dynamic.xml
 .idea/**/uiDesigner.xml
 
-# Gradle:
+# Gradle
 .idea/**/gradle.xml
 .idea/**/libraries
 
 # CMake
 cmake-build-debug/
+cmake-build-release/
 
-# Mongo Explorer plugin:
+# Mongo Explorer plugin
 .idea/**/mongoSettings.xml
 
-## File-based project format:
+# File-based project format
 *.iws
-
-## Plugin-specific files:
 
 # IntelliJ
 out/
@@ -140,20 +161,8 @@ crashlytics.properties
 crashlytics-build.properties
 fabric.properties
 
-## Gradle.gitignore
-## https://github.com/github/gitignore
-
-.gradle
-/build/
-
-# Ignore Gradle GUI config
-gradle-app.setting
-
-# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
-!gradle-wrapper.jar
-
-# Cache of project
-.gradletasknamecache
+# Editor-based Rest Client
+.idea/httpRequests
 
 ## Linux.gitignore
 ## https://github.com/github/gitignore

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,29 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <Objective-C-extensions>
+      <file>
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Import" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Macro" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Typedef" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Enum" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Constant" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Global" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Struct" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="FunctionPredecl" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Function" />
+      </file>
+      <class>
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Property" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Synthesize" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InitMethod" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="StaticMethod" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InstanceMethod" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="DeallocMethod" />
+      </class>
+      <extensions>
+        <pair source="cpp" header="h" fileNamingConvention="NONE" />
+        <pair source="c" header="h" fileNamingConvention="NONE" />
+      </extensions>
+    </Objective-C-extensions>
+  </code_scheme>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -10,11 +10,12 @@
     <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />
     <option name="myNullables">
       <value>
-        <list size="4">
+        <list size="5">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
-          <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.Nullable" />
-          <item index="3" class="java.lang.String" itemvalue="android.support.annotation.Nullable" />
+          <item index="2" class="java.lang.String" itemvalue="javax.annotation.CheckForNull" />
+          <item index="3" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.Nullable" />
+          <item index="4" class="java.lang.String" itemvalue="android.support.annotation.Nullable" />
         </list>
       </value>
     </option>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Nov 07 12:25:05 PST 2017
+#Thu Apr 05 09:54:54 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/zapic-demo/build.gradle
+++ b/zapic-demo/build.gradle
@@ -29,4 +29,5 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':zapic')
     implementation 'com.android.support:support-annotations:27.1.0'
+    implementation 'com.squareup:seismic:1.0.2'
 }

--- a/zapic-demo/src/main/AndroidManifest.xml
+++ b/zapic-demo/src/main/AndroidManifest.xml
@@ -9,14 +9,23 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/FullscreenTheme">
-
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+        <activity
+            android:name=".SettingsActivity"
+            android:label="@string/app_name"
+            android:parentActivityName=".MainActivity"
+            android:theme="@android:style/Theme.DeviceDefault.Light">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".MainActivity" />
         </activity>
 
         <meta-data

--- a/zapic-demo/src/main/java/com/zapic/androiddemo/SettingsActivity.java
+++ b/zapic-demo/src/main/java/com/zapic/androiddemo/SettingsActivity.java
@@ -1,0 +1,66 @@
+package com.zapic.androiddemo;
+
+import android.content.res.Configuration;
+import android.os.Bundle;
+import android.preference.Preference;
+import android.preference.PreferenceActivity;
+import android.app.ActionBar;
+import android.preference.PreferenceFragment;
+import android.preference.PreferenceManager;
+
+import java.util.List;
+
+public class SettingsActivity extends PreferenceActivity {
+    public static final String KEY_CACHE = "zapic_cache";
+
+    public static final String KEY_URL = "zapic_url";
+
+    private static final Preference.OnPreferenceChangeListener sSummaryValueListener = new Preference.OnPreferenceChangeListener() {
+        @Override
+        public boolean onPreferenceChange(Preference preference, Object value) {
+            String stringValue = value.toString();
+            preference.setSummary(stringValue);
+            return true;
+        }
+    };
+
+    private static void bindSummaryValueListener(Preference preference) {
+        preference.setOnPreferenceChangeListener(sSummaryValueListener);
+        sSummaryValueListener.onPreferenceChange(preference, PreferenceManager.getDefaultSharedPreferences(preference.getContext()).getString(preference.getKey(), ""));
+    }
+
+    @Override
+    public void onBuildHeaders(List<Header> target) {
+        loadHeadersFromResource(R.xml.pref_headers, target);
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        ActionBar actionBar = getActionBar();
+        if (actionBar != null) {
+            actionBar.setDisplayHomeAsUpEnabled(true);
+        }
+    }
+
+    @Override
+    public boolean onIsMultiPane() {
+        return (this.getResources().getConfiguration().screenLayout & Configuration.SCREENLAYOUT_SIZE_MASK) >= Configuration.SCREENLAYOUT_SIZE_XLARGE;
+    }
+
+    @Override
+    protected boolean isValidFragment(String fragmentName) {
+        return PreferenceFragment.class.getName().equals(fragmentName) || ZapicPreferenceFragment.class.getName().equals(fragmentName);
+    }
+
+    public static class ZapicPreferenceFragment extends PreferenceFragment {
+        @Override
+        public void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+            this.addPreferencesFromResource(R.xml.pref_zapic);
+
+            SettingsActivity.bindSummaryValueListener(this.findPreference(KEY_URL));
+        }
+    }
+}

--- a/zapic-demo/src/main/res/drawable/ic_info_black_24dp.xml
+++ b/zapic-demo/src/main/res/drawable/ic_info_black_24dp.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zm1,15h-2v-6h2v6zm0,-8h-2V7h2v2z" />
+</vector>

--- a/zapic-demo/src/main/res/values/strings.xml
+++ b/zapic-demo/src/main/res/values/strings.xml
@@ -3,6 +3,13 @@
     <string name="challenges_button">Challenges</string>
     <string name="zapic_button">Zapic</string>
 
+    <string name="pref_header_zapic">Zapic</string>
+    <string name="pref_title_zapic_url">Server URL</string>
+    <string name="pref_default_zapic_url">https://app.zapic.net</string>
+    <string name="pref_title_zapic_cache">Enable Cache</string>
+    <string name="pref_summary_zapic_cache">Load HTML from disk cache</string>
+    <string name="pref_default_zapic_cache">true</string>
+
     <string name="play_games_app_id">853726039702</string>
     <string name="play_games_web_client_id">853726039702-d1er1k1d6bvjg6lf9fg5rnja64scrk9s.apps.googleusercontent.com</string>
 </resources>

--- a/zapic-demo/src/main/res/xml/pref_headers.xml
+++ b/zapic-demo/src/main/res/xml/pref_headers.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<preference-headers xmlns:android="http://schemas.android.com/apk/res/android">
+    <header
+        android:fragment="com.zapic.androiddemo.SettingsActivity$ZapicPreferenceFragment"
+        android:icon="@drawable/ic_info_black_24dp"
+        android:title="@string/pref_header_zapic" />
+</preference-headers>

--- a/zapic-demo/src/main/res/xml/pref_zapic.xml
+++ b/zapic-demo/src/main/res/xml/pref_zapic.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <EditTextPreference
+        android:capitalize="none"
+        android:defaultValue="@string/pref_default_zapic_url"
+        android:inputType="textUri"
+        android:key="zapic_url"
+        android:maxLines="1"
+        android:selectAllOnFocus="true"
+        android:singleLine="true"
+        android:title="@string/pref_title_zapic_url" />
+    <CheckBoxPreference
+        android:defaultValue="@string/pref_default_zapic_cache"
+        android:key="zapic_cache"
+        android:summary="@string/pref_summary_zapic_cache"
+        android:title="@string/pref_title_zapic_cache" />
+</PreferenceScreen>

--- a/zapic/src/main/java/com/zapic/sdk/android/AppSourceAsyncTask.java
+++ b/zapic/src/main/java/com/zapic/sdk/android/AppSourceAsyncTask.java
@@ -68,7 +68,7 @@ final class AppSourceAsyncTask extends AsyncTask<Void, Integer, AppSource> imple
     @Override
     @WorkerThread
     protected AppSource doInBackground(final Void... voids) {
-        final AppSource cachedAppSource = this.getFromCache();
+        final AppSource cachedAppSource = AppSourceConfig.isCacheEnabled() ? this.getFromCache() : null;
         if (cachedAppSource != null) {
             final long lastValidated = cachedAppSource.getLastValidated();
             final long now = System.currentTimeMillis();

--- a/zapic/src/main/java/com/zapic/sdk/android/AppSourceConfig.java
+++ b/zapic/src/main/java/com/zapic/sdk/android/AppSourceConfig.java
@@ -1,0 +1,81 @@
+package com.zapic.sdk.android;
+
+import android.support.annotation.CheckResult;
+import android.support.annotation.NonNull;
+
+/**
+ * A utility class that overrides the behavior of loading the Zapic JavaScript application source
+ * for debug purposes.
+ * <p>
+ * <em>These settings will break production apps. You should only use these settings when
+ * debugging apps with Zapic support engineers.</em>
+ *
+ * @author Kyle Dodson
+ * @since 1.0.4
+ */
+@SuppressWarnings("DeprecatedIsStillUsed")
+public final class AppSourceConfig {
+    /**
+     * The Zapic application source URL.
+     */
+    @NonNull
+    private static final String APP_SOURCE_URL = "https://app.zapic.net";
+
+    /**
+     * A value indicating whether to use a cached application source.
+     */
+    private static boolean mCache = true;
+
+    @NonNull
+    private static String mUrl = APP_SOURCE_URL;
+
+    /**
+     * Disables using a cached application source.
+     */
+    @Deprecated
+    public static void disableCache() {
+        mCache = false;
+    }
+
+    /**
+     * Enables using a cached application source.
+     */
+    @Deprecated
+    public static void enableCache() {
+        mCache = true;
+    }
+
+    /**
+     * Gets the application source URL.
+     *
+     * @return The application source URL.
+     */
+    @CheckResult
+    @Deprecated
+    @NonNull
+    public static String getUrl() {
+        return mUrl;
+    }
+
+    /**
+     * Gets a value indicating whether to use a cached application source.
+     *
+     * @return <code>true</code> to use a cached application source; <code>false</code> to not use a
+     * cached application source.
+     */
+    @CheckResult
+    @Deprecated
+    public static boolean isCacheEnabled() {
+        return mCache;
+    }
+
+    /**
+     * Sets the application source URL.
+     *
+     * @param url The application source URL.
+     */
+    @Deprecated
+    public static void setUrl(@NonNull String url) {
+        mUrl = url;
+    }
+}

--- a/zapic/src/main/java/com/zapic/sdk/android/WebViewManager.java
+++ b/zapic/src/main/java/com/zapic/sdk/android/WebViewManager.java
@@ -45,12 +45,6 @@ final class WebViewManager {
     private static final String TAG = "WebViewManager";
 
     /**
-     * The Zapic JavaScript application source URL.
-     */
-    @NonNull
-    private static final String APP_SOURCE_URL = "https://app.zapic.net";
-
-    /**
      * A weak reference to the {@link WebViewManager} instance.
      * <p>
      * A strong reference to the {@link WebViewManager} instance is kept by {@link ZapicActivity}
@@ -364,6 +358,7 @@ final class WebViewManager {
     }
 
     @MainThread
+    @SuppressWarnings("deprecation")
     void onActivityCreated(@NonNull final ZapicActivity activity) {
         this.mActivity = activity;
         if (this.mWebView == null) {
@@ -373,7 +368,7 @@ final class WebViewManager {
 
             this.createEventHandler(activity);
             this.createWebView(activity);
-            this.mAsyncTask = new AppSourceAsyncTask(APP_SOURCE_URL, activity.getApplicationContext().getCacheDir()).execute();
+            this.mAsyncTask = new AppSourceAsyncTask(AppSourceConfig.getUrl(), activity.getApplicationContext().getCacheDir()).execute();
         } else if (this.mStarted) {
             this.mWebView.evaluateJavascript("window.zapic.dispatch({ type: 'OPEN_PAGE', payload: '" + activity.getPageParameter() + "' })", null);
         }
@@ -436,6 +431,7 @@ final class WebViewManager {
     }
 
     @MainThread
+    @SuppressWarnings("deprecation")
     void onFragmentCreated(@NonNull final ZapicFragment fragment) {
         this.mFragments.add(fragment);
         if (this.mWebView == null) {
@@ -445,7 +441,7 @@ final class WebViewManager {
 
             this.createEventHandler(fragment.getActivity());
             this.createWebView(fragment.getActivity());
-            this.mAsyncTask = new AppSourceAsyncTask(APP_SOURCE_URL, fragment.getActivity().getApplicationContext().getCacheDir()).execute();
+            this.mAsyncTask = new AppSourceAsyncTask(AppSourceConfig.getUrl(), fragment.getActivity().getApplicationContext().getCacheDir()).execute();
         }
     }
 
@@ -633,9 +629,11 @@ final class WebViewManager {
     }
 
     @MainThread
+    @SuppressWarnings("deprecation")
     void submitLoadApp(@NonNull final AppSource appSource) {
         if (this.mWebView != null) {
-            this.mWebView.loadDataWithBaseURL(APP_SOURCE_URL, appSource.getHtml(), "text/html", "utf-8", APP_SOURCE_URL);
+            final String url = AppSourceConfig.getUrl();
+            this.mWebView.loadDataWithBaseURL(url, appSource.getHtml(), "text/html", "utf-8", url);
         }
     }
 }


### PR DESCRIPTION
This adds a preferences activity to the demo app. The activity may be opened by shaking the device. The preferences may be used to override the URL of the loaded HTML file and to enable/disable the disk cache. This option exists purely to debug and troubleshoot WebView issues. The APIs introduced in this PR are not intended to be used in production apps. The APIs would likely cause issues for end users if used in production apps.

This also upgrades to Gradle 4.4 and the project structure to Android Studio 3.1.