### PR TITLE
Added a Zapic.NOTIFICATION_TAG constant for SDK parity

### DIFF
--- a/zapic/src/main/java/com/zapic/sdk/android/Zapic.java
+++ b/zapic/src/main/java/com/zapic/sdk/android/Zapic.java
@@ -55,6 +55,11 @@ import java.util.Iterator;
  */
 public final class Zapic {
     /**
+     * The name of the OneSignal push notification tag.
+     */
+    public static final String NOTIFICATION_TAG = "zapic_player_token";
+
+    /**
      * A synchronization lock for {@code sInstance} writes.
      */
     @NonNull


### PR DESCRIPTION
The other Zapic SDKs provide some sort of a notification tag constant. This is the tag name that must be used when associating a Zapic user with a OneSignal device.