### PR TITLE
Added LOGIN and COMPETITION_LIST page names

### DIFF
--- a/zapic/src/main/java/com/zapic/sdk/android/ZapicPages.java
+++ b/zapic/src/main/java/com/zapic/sdk/android/ZapicPages.java
@@ -19,10 +19,22 @@ public final class ZapicPages {
     public static final String CHALLENGE_LIST = "Challenges";
 
     /**
-     * Identifies a page that shows the a form to create a new challenge for the current game.
+     * Identifies a page that shows the list of competitions for the current game.
+     */
+    @NonNull
+    public static final String COMPETITION_LIST = "Competitions";
+
+    /**
+     * Identifies a page that shows the create a new challenge form for the current game.
      */
     @NonNull
     public static final String CREATE_CHALLENGE = "CreateChallenge";
+
+    /**
+     * Identifies a page that shows the login form for the current player.
+     */
+    @NonNull
+    public static final String LOGIN = "Login";
 
     /**
      * Identifies a page that shows the profile for the current player.


### PR DESCRIPTION
Calling `Zapic.showPage(ZapicPages.LOGIN);` will show the Zapic UI if the current user is not logged in. The Zapic UI will present the login/register page. The user may dismiss the Zapic UI and return to the game, or the user may login/register. At the end of the login/register workflow, the Zapic UI will close and return to the game.

Calling `Zapic.showPage(COMPETITION_LIST);` will show the Zapic UI and present the home page.