### PR TITLE
Added support for sharing via the default email or SMS app

### DIFF
--- a/zapic/src/main/java/com/zapic/sdk/android/ViewManager.java
+++ b/zapic/src/main/java/com/zapic/sdk/android/ViewManager.java
@@ -482,9 +482,25 @@ final class ViewManager {
     }
 
     /**
+     * Shows an app to share content.
+     * <p>
+     * This will ignore the intent if a {@link ZapicActivity} instance does not exist.
+     *
+     * @param intent The intent.
+     */
+    @MainThread
+    void showShare(@NonNull final Intent intent) {
+        if (mActivity != null) {
+            if (intent.resolveActivity(mActivity.getPackageManager()) != null) {
+                mActivity.startActivity(intent);
+            }
+        }
+    }
+
+    /**
      * Shows an app chooser to share content on the {@link ZapicActivity} instance.
      * <p>
-     * This will ignore the app chooser if a {@link ZapicActivity} instance does not exist.
+     * This will ignore the intent if a {@link ZapicActivity} instance does not exist.
      *
      * @param intent The intent.
      */


### PR DESCRIPTION
The Zapic UI now provides email/SMS buttons for sharing content (e.g. challenge links). These buttons will skip the "chooser" and go straight to the user's default email/SMS app.